### PR TITLE
Don't use the same selector as the registered 'AR' component

### DIFF
--- a/AR/src/app/home/home.component.ts
+++ b/AR/src/app/home/home.component.ts
@@ -6,7 +6,7 @@ import { Color } from "tns-core-modules/color";
 registerElement("AR", () => require("nativescript-ar").AR);
 
 @Component({
-  selector: "ar",
+  selector: "argh",
   moduleId: module.id,
   template: `
 <ActionBar title="NativeScript AR"></ActionBar>


### PR DESCRIPTION
That naming clash means the ng component will try to load the AR view, and that's probably not what you intended.